### PR TITLE
Get rid of the 'test' navigation

### DIFF
--- a/content/navigation/test.yaml
+++ b/content/navigation/test.yaml
@@ -1,3 +1,0 @@
-title: Test
-collections:
-  - pages


### PR DESCRIPTION
Just pulled this starter kit down for some testing & realised there's a blank, useless 'Test' navigation in here. This PR removes it as it's not used anywhere. 